### PR TITLE
use kernel etherdevice interface to set hw address

### DIFF
--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -9922,8 +9922,11 @@ static int rtw_mp_efuse_set(struct net_device *dev,
 		rtw_hal_read_chip_info(padapter);
 		/* set mac addr*/
 		rtw_macaddr_cfg(adapter_mac_addr(padapter), get_hal_mac_addr(padapter));
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5, 17, 0))
+		eth_hw_addr_set(padapter->pnetdev, get_hal_mac_addr(padapter));
+#else
 		_rtw_memcpy(padapter->pnetdev->dev_addr, get_hal_mac_addr(padapter), ETH_ALEN); /* set mac addr to net_device */
-
+#endif
 #ifdef CONFIG_P2P
 		rtw_init_wifidirect_addrs(padapter, adapter_mac_addr(padapter), adapter_mac_addr(padapter));
 #endif

--- a/os_dep/linux/mlme_linux.c
+++ b/os_dep/linux/mlme_linux.c
@@ -402,8 +402,11 @@ int hostapd_mode_init(_adapter *padapter)
 	mac[4] = 0x11;
 	mac[5] = 0x12;
 
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5, 17, 0))
+	eth_hw_addr_set(pnetdev, mac);
+#else
 	_rtw_memcpy(pnetdev->dev_addr, mac, ETH_ALEN);
-
+#endif
 
 	rtw_netif_carrier_off(pnetdev);
 

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1187,7 +1187,11 @@ static int rtw_net_set_mac_address(struct net_device *pnetdev, void *addr)
 	}
 
 	_rtw_memcpy(adapter_mac_addr(padapter), sa->sa_data, ETH_ALEN); /* set mac addr to adapter */
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5, 17, 0))
+	eth_hw_addr_set(pnetdev, sa->sa_data); /* set mac addr to net_device */
+#else
 	_rtw_memcpy(pnetdev->dev_addr, sa->sa_data, ETH_ALEN); /* set mac addr to net_device */
+#endif
 
 #if 0
 	if (rtw_is_hw_init_completed(padapter)) {
@@ -1612,8 +1616,11 @@ int rtw_os_ndev_register(_adapter *adapter, const char *name)
 
 	/* alloc netdev name */
 	rtw_init_netdev_name(ndev, name);
-
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5, 17, 0))
+	eth_hw_addr_set(ndev, adapter_mac_addr(adapter)); /* set mac addr to net_device */
+#else
 	_rtw_memcpy(ndev->dev_addr, adapter_mac_addr(adapter), ETH_ALEN);
+#endif
 #if defined(CONFIG_NET_NS)
 	dev_net_set(ndev, wiphy_net(adapter_to_wiphy(adapter)));
 #endif //defined(CONFIG_NET_NS)
@@ -2529,7 +2536,11 @@ int _netdev_vir_if_open(struct net_device *pnetdev)
 		rtw_mbid_camid_alloc(padapter, adapter_mac_addr(padapter));
 #endif
 		rtw_init_wifidirect_addrs(padapter, adapter_mac_addr(padapter), adapter_mac_addr(padapter));
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5, 17, 0))
+		eth_hw_addr_set(pnetdev, adapter_mac_addr(padapter));
+#else
 		_rtw_memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
+#endif
 	}
 #endif /*CONFIG_PLATFORM_INTEL_BYT*/
 
@@ -3166,7 +3177,11 @@ int _netdev_open(struct net_device *pnetdev)
 		rtw_mbid_camid_alloc(padapter, adapter_mac_addr(padapter));
 #endif
 		rtw_init_wifidirect_addrs(padapter, adapter_mac_addr(padapter), adapter_mac_addr(padapter));
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5, 17, 0))
+		eth_hw_addr_set(pnetdev, adapter_mac_addr(padapter));
+#else
 		_rtw_memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
+#endif
 #endif /* CONFIG_PLATFORM_INTEL_BYT */
 
 		rtw_clr_surprise_removed(padapter);

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2167,8 +2167,11 @@ int rtw_change_ifname(_adapter *padapter, const char *ifname)
 
 	rtw_init_netdev_name(pnetdev, ifname);
 
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5, 17, 0))
+	eth_hw_addr_set(pnetdev, adapter_mac_addr(padapter));
+#else
 	_rtw_memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
-
+#endif
 	if (rtnl_lock_needed)
 		ret = register_netdev(pnetdev);
 	else


### PR DESCRIPTION
Fixes crash when the device is accessed and the following warning is displayed "Incorrect netdev->dev_addr".

traces::
```
[  914.666202] ------------[ cut here ]------------
t_card_state wlan0 up true
[  914.670845] netdevice: wlan0: Incorrect netdev->dev_addr
[  914.689001] [ WARNING: CPU: 3 PID: 1459 at net/core/dev_addr_lists.c:519 dev_addr_check+0x90/0x12c
[  914.690641] Modules linked in: 88XXau_ohd(O) overlay fsl_jr_uio caam_jr caamkeyblob_desc caamhash_desc caamalg_desc crypto_engine authenc libdes crct10dif_ce polyval_ce polyval_generic snd_soc_imx_card snd_soc_imx_spdif snd_soc_ak4458 snd_soc_ak5558 caam secvio error snd_soc_fsl_spdif snd_soc_fsl_sai snd_soc_fsl_micfil snd_soc_fsl_utils gpio_ir_recv rc_core fuse
[  914.722772] CPU: 3 PID: 1459 Comm: ip Tainted: G        W  O       6.1.55+g770c5fe2c1d1 #1
[  914.731038] Hardware name: FSL i.MX8MM EVK board (DT)
[  914.736088] pstate: 60000005 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[  914.745908] pc : dev_addr_check+0x90/0x12c
[  914.752345] lr : dev_addr_check+0x90/0x12c
[  914.756447] sp : ffff80001261b590
[  914.759761] x29: ffff80001261b590 x28: ffff7cba05c6f010 x27: 0000000000000000
[  914.766903] x26: ffffc73807ff6e28 x25: ffff7cba05c6f010 x24: 0000000000000001
[  914.774046] x23: ffff7cba08e23258 x22: 0000000000001002 x21: ffffc73807ff6e28
[  914.781190] x20: ffff7cba08e23000 x19: ffff7cba08e23000 x18: 0000000000000006
[  914.788332] x17: 0000000000000000 x16: 0000000000000000 x15: ffff80001261b060
[  914.795472] x14: 0000000000000000 x13: ffffc738259e2508 x12: 0000000000001425
[  914.802615] x11: 00000000000006b7 x10: ffffc73825a3a508 x9 : ffffc738259e2508
[  914.809756] x8 : 00000000ffffefff x7 : ffffc73825a3a508 x6 : 80000000fffff000
[  914.816899] x5 : ffff7cba55ba7a18 x4 : ffff7cba55ba7a18 x3 : ffff7cba55baac20
[  914.824041] x2 : 0000000000000000 x1 : 0000000000000000 x0 : ffff7cba044a8000
[  914.831186] Call trace:
[  914.833634]  dev_addr_check+0x90/0x12c
[  914.837389]  __dev_open+0x44/0x1e0
[  914.840797]  __dev_change_flags+0x194/0x210
[  914.844984]  dev_change_flags+0x24/0x64
[  914.848827]  do_setlink+0x2b8/0xfb0
[  914.852320]  __rtnl_newlink+0x4f8/0x854
[  914.856159]  rtnl_newlink+0x50/0x7c
[  914.859653]  rtnetlink_rcv_msg+0x130/0x380
[  914.863751]  netlink_rcv_skb+0x60/0x130
[  914.867591]  rtnetlink_rcv+0x18/0x24
[  914.871172]  netlink_unicast+0x2fc/0x36c
[  914.875097]  netlink_sendmsg+0x1ac/0x420
[  914.879020]  ____sys_sendmsg+0x21c/0x27c
[  914.882950]  ___sys_sendmsg+0xb0/0x110
[  914.886702]  __sys_sendmsg+0x88/0xf0
[  914.890280]  __arm64_sys_sendmsg+0x24/0x30
[  914.894377]  invoke_syscall+0x48/0x114
[  914.898134]  el0_svc_common.constprop.0+0xcc/0xec
[  914.902842]  do_el0_svc+0x2c/0xd0
[  914.906162]  el0_svc+0x2c/0x84
[  914.909222]  el0t_64_sync_handler+0xf4/0x120
[  914.913494]  el0t_64_sync+0x18c/0x190
[  914.917159] ---[ end trace 0000000000000000 ]---
```
```
[ 2645.141119] ------------[ cut here ]------------
[ 2645.145761] netdevice: wlan0 (unregistered): Incorrect netdev->dev_addr
[ 2645.152439] WARNING: CPU: 0 PID: 1595 at net/core/dev_addr_lists.c:519 dev_addr_check+0x90/0x12c
[ 2645.161243] Modules linked in: overlay fsl_jr_uio caam_jr caamkeyblob_desc caamhash_desc caamalg_desc crypto_engine authenc libdes 88XXau_ohd(O) snd_soc_fsl_asoc_card snd_soc_imx_audmux crct10dif_ce polyval_ce snd_soc_imx_hdmi polyval_generic snd_soc_imx_card snd_soc_fsl_xcvr imx8_media_dev(C) snd_soc_wm8960 dw_hdmi_cec snd_soc_fsl_easrc snd_soc_fsl_sai snd_soc_fsl_micfil snd_soc_fsl_asrc snd_soc_fsl_utils snd_soc_fsl_aud2htx secvio caam flexcan error can_dev imx_dsp_rproc fuse
[ 2645.203613] CPU: 0 PID: 1595 Comm: kworker/0:1 Tainted: G         C O       6.1.55+g770c5fe2c1d1 #1
[ 2645.212660] Hardware name: NXP i.MX8MPlus EVK board (DT)
[ 2645.217970] Workqueue: usb_hub_wq hub_event
[ 2645.222158] pstate: 60000005 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[ 2645.229123] pc : dev_addr_check+0x90/0x12c
[ 2645.233225] lr : dev_addr_check+0x90/0x12c
[ 2645.237328] sp : ffff80000bd0ba20
[ 2645.240641] x29: ffff80000bd0ba20 x28: ffff0000d4090000 x27: ffff0000d17a2800
[ 2645.247779] x26: ffff0000dc9ce800 x25: ffff0000dc9ce8a8 x24: 0000000000000001
[ 2645.254918] x23: ffff80000159f380 x22: ffff0000d1395000 x21: 0000000000000122
[ 2645.262060] x20: ffff0000d1395000 x19: ffff0000d1395000 x18: 0000000000000006
[ 2645.269201] x17: 0000000000000000 x16: 0000000000000000 x15: ffff80000bd0b4f0
[ 2645.276342] x14: 0000000000000000 x13: ffff800009de2508 x12: 00000000000013f2
[ 2645.283484] x11: 00000000000006a6 x10: ffff800009e3a508 x9 : ffff800009de2508
[ 2645.290623] x8 : 00000000ffffefff x7 : ffff800009e3a508 x6 : 80000000fffff000
[ 2645.297765] x5 : ffff0001793b2a18 x4 : ffff0001793b2a18 x3 : ffff0001793b5c20
[ 2645.304906] x2 : 0000000000000000 x1 : 0000000000000000 x0 : ffff0000d0ecc9c0
[ 2645.312048] Call trace:
[ 2645.314494]  dev_addr_check+0x90/0x12c
[ 2645.318247]  dev_addr_flush+0x24/0x90
[ 2645.321914]  free_netdev+0x78/0x1b0
[ 2645.325405]  rtw_free_netdev+0x1c/0x2c [88XXau_ohd]
[ 2645.330489]  rtw_os_ndev_free+0x24/0x38 [88XXau_ohd]
[ 2645.335613]  rtw_usb_primary_adapter_deinit+0x6c/0xd4 [88XXau_ohd]
[ 2645.341966]  rtw_dev_remove+0x80/0x104 [88XXau_ohd]
[ 2645.346995]  usb_unbind_interface+0x78/0x26c
[ 2645.351272]  device_remove+0x70/0x80
[ 2645.354849]  device_release_driver_internal+0x1e4/0x250
[ 2645.360078]  device_release_driver+0x18/0x24
[ 2645.364352]  usb_forced_unbind_intf+0x44/0x90
[ 2645.368712]  usb_reset_device+0xe4/0x240
[ 2645.372638]  hub_event+0x820/0x1554
[ 2645.376130]  process_one_work+0x1d4/0x330
[ 2645.380143]  worker_thread+0x6c/0x42c
[ 2645.383806]  kthread+0x108/0x10c
[ 2645.387037]  ret_from_fork+0x10/0x20
[ 2645.390616] ---[ end trace 0000000000000000 ]---
```